### PR TITLE
Fix packagist error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,20 +5,12 @@
     "license": "Apache-2.0",
     "authors": [
       {
-        "name": "Nicolas Leroy",
-        "email": "nicolas.leroy@gmail.com"
-      },
-      {
-        "name": "Jonas Verhaeghe",
-        "email": "Jonas@cultuurnet.be"
-      },
-      {
-        "name": "Kristof Coomans",
-        "email": "kristof@2dotstwice.be"
+        "name": "Publiq vzw",
+        "email": "info@publiq.be"
       }
     ],
     "require": {
-        "cultuurnet/Auth": "~1.2"
+        "cultuurnet/auth": "~1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",


### PR DESCRIPTION
### Fixed

- Fixed an update error on Packagist caused by an uppercased letter in a dependency name

---

Original message from Packagist:

```
The cultuurnet/uitid-credentials package of which you are a maintainer has
failed to update due to invalid data contained in your composer.json.
Please address this as soon as possible since the package stopped updating.

It is recommended that you use `composer validate` to check for errors when you
change your composer.json.

Below is the full update log which should highlight errors as
"Skipped branch ...":

[Composer\Repository\InvalidRepositoryException]: Some branches contained invalid data and were discarded, it is advised to review the log and fix any issues present in branches

Reading composer.json of cultuurnet/uitid-credentials (feature/symfony-3)
Found cached composer.json of cultuurnet/uitid-credentials (dev-feature/symfony-3)
Reading composer.json of cultuurnet/uitid-credentials (master)
Importing branch master (dev-master)
Skipped branch master, Invalid package information: 
Deprecation warning: require.cultuurnet/Auth is invalid, it should not contain uppercase characters. Please use cultuurnet/auth instead. Make sure you fix this as Composer 2.0 will error.
```